### PR TITLE
Improve core api and test

### DIFF
--- a/src/main/groovy/net/gvmtool/client/GvmClient.groovy
+++ b/src/main/groovy/net/gvmtool/client/GvmClient.groovy
@@ -6,9 +6,18 @@ import wslite.rest.RESTClient
 class GvmClient {
 
     RESTClient restClient
+    String gvmHome
 
     GvmClient(String apiUrl) {
+        this(apiUrl, System.getProperty('user.home') + '/.gvm')
+    }
+
+    GvmClient(String apiUrl, String gvmHome) {
+        Objects.requireNonNull(gvmHome, "gvmHome must not be null")
+        assert new File(gvmHome).isDirectory(): "Directory '$gvmHome' does not exist"
+
         this.restClient = new RESTClient(apiUrl)
+        this.gvmHome = gvmHome
     }
 
     List<String> getRemoteCandidates() {

--- a/src/main/groovy/net/gvmtool/client/GvmClient.groovy
+++ b/src/main/groovy/net/gvmtool/client/GvmClient.groovy
@@ -21,16 +21,19 @@ class GvmClient {
         }
     }
 
-    List<Version> getVersionsFor(String candidate) {
-        def versions = []
+    List<String> getRemoteVersionsFor(String candidate) {
         try {
-            def csv = restClient.get(path: "/candidates/$candidate").text
-            csv.tokenize(',').each { versions << new Version(name:it) }
+              def csv = restClient.get(path: "/candidates/$candidate").text
+          if (csv == 'invalid') {
+              return []
+          }
+          else {
+              return csv.tokenize(',')
+          }
 
         } catch (HTTPClientException hce) {
             throw new GvmClientException("Error on retrieving versions.", hce)
         }
-        versions
     }
 
 

--- a/src/main/groovy/net/gvmtool/client/GvmClient.groovy
+++ b/src/main/groovy/net/gvmtool/client/GvmClient.groovy
@@ -11,17 +11,14 @@ class GvmClient {
         this.restClient = new RESTClient(apiUrl)
     }
 
-    List<Candidate> getCandidates() {
-        def candidates = []
+    List<String> getCandidates() {
         try {
-
             def csv = restClient.get(path: "/candidates").text
-            csv.tokenize(',').each { candidates << new Candidate(name:it) }
+            return csv.tokenize(',')
 
         } catch(HTTPClientException hce) {
             throw new GvmClientException("Error on retrieving candidates.", hce)
         }
-        candidates
     }
 
     List<Version> getVersionsFor(String candidate) {
@@ -35,4 +32,6 @@ class GvmClient {
         }
         versions
     }
+
+
 }

--- a/src/main/groovy/net/gvmtool/client/GvmClient.groovy
+++ b/src/main/groovy/net/gvmtool/client/GvmClient.groovy
@@ -11,7 +11,7 @@ class GvmClient {
         this.restClient = new RESTClient(apiUrl)
     }
 
-    List<String> getCandidates() {
+    List<String> getRemoteCandidates() {
         try {
             def csv = restClient.get(path: "/candidates").text
             return csv.tokenize(',')

--- a/src/test/groovy/net/gvmtool/client/GvmClientSpec.groovy
+++ b/src/test/groovy/net/gvmtool/client/GvmClientSpec.groovy
@@ -13,7 +13,7 @@ class GvmClientSpec extends Specification {
         gvmClient = new GvmClient(apiUrl)
     }
 
-    void "should retrieve a list of candidate names"() {
+    void "should retrieve a list of remote candidate names"() {
         given:
         def candidates = "gaiden,gradle,grails,griffon,groovy,groovyserv,lazybones,play,springboot,vertx".split(",")
 
@@ -24,7 +24,7 @@ class GvmClientSpec extends Specification {
         results.containsAll(candidates)
     }
 
-    void "should handle communication error on retrieving of candidates"() {
+    void "should handle communication error on retrieving of remote candidates"() {
         given:
         def mockRestClient = Mock(RESTClient)
         gvmClient.restClient = mockRestClient
@@ -39,7 +39,7 @@ class GvmClientSpec extends Specification {
         thrown(GvmClientException)
     }
 
-    void "should retrieve all remote versions for existing candidate"() {
+    void "should retrieve all remote versions for existing remote candidate"() {
         given:
         def candidate = "groovy"
 
@@ -51,7 +51,7 @@ class GvmClientSpec extends Specification {
         versions.find { it == "2.1.9" }
     }
 
-    void "should return an empty list for non existing candidate"() {
+    void "should return an empty list for non existing remote candidate"() {
         given:
         def candidate = "dada3*"
 
@@ -62,7 +62,7 @@ class GvmClientSpec extends Specification {
         versions.empty
     }
 
-    void "should handle communication error on retrieving candidate versions"() {
+    void "should handle communication error on retrieving remote candidate versions"() {
         given:
         def candidate = "groovy"
         def mockRestClient = Mock(RESTClient)

--- a/src/test/groovy/net/gvmtool/client/GvmClientSpec.groovy
+++ b/src/test/groovy/net/gvmtool/client/GvmClientSpec.groovy
@@ -13,16 +13,15 @@ class GvmClientSpec extends Specification {
         gvmClient = new GvmClient(apiUrl)
     }
 
-    void "should retrieve a list of candidates"() {
+    void "should retrieve a list of candidate names"() {
         given:
-        def candidates = "gaiden,gradle,grails,griffon,groovy,groovyserv,lazybones,play,springboot,vertx"
+        def candidates = "gaiden,gradle,grails,griffon,groovy,groovyserv,lazybones,play,springboot,vertx".split(",")
 
         when:
-        List<Candidate> results = gvmClient.getCandidates()
+        List<String> results = gvmClient.getCandidates()
 
         then:
-        results.find { it.name == "groovy" }
-        results.find { it.name == "grails" }
+        results.containsAll(candidates)
     }
 
     void "should handle communication error on retrieving of candidates"() {

--- a/src/test/groovy/net/gvmtool/client/GvmClientSpec.groovy
+++ b/src/test/groovy/net/gvmtool/client/GvmClientSpec.groovy
@@ -7,9 +7,10 @@ import wslite.rest.RESTClient
 class GvmClientSpec extends Specification {
 
     GvmClient gvmClient
+    String apiUrl
 
     void setup(){
-        def apiUrl = "http://dev.gvmtool.net"
+        apiUrl = "http://dev.gvmtool.net"
         gvmClient = new GvmClient(apiUrl)
     }
 
@@ -78,4 +79,25 @@ class GvmClientSpec extends Specification {
         thrown(GvmClientException)
     }
 
+    void "should throw NullPointerException if null is given as gvmHome"() {
+        given:
+        String gvmHome = null
+
+        when:
+        new GvmClient(apiUrl, gvmHome)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    void "should throw AssertionError if bogus is given as gvmHome"() {
+        given:
+        String gvmHome = "/superroot"
+
+        when:
+        new GvmClient(apiUrl, gvmHome)
+
+        then:
+        thrown(AssertionError)
+    }
 }

--- a/src/test/groovy/net/gvmtool/client/GvmClientSpec.groovy
+++ b/src/test/groovy/net/gvmtool/client/GvmClientSpec.groovy
@@ -18,7 +18,7 @@ class GvmClientSpec extends Specification {
         def candidates = "gaiden,gradle,grails,griffon,groovy,groovyserv,lazybones,play,springboot,vertx".split(",")
 
         when:
-        List<String> results = gvmClient.getCandidates()
+        List<String> results = gvmClient.getRemoteCandidates()
 
         then:
         results.containsAll(candidates)
@@ -30,7 +30,7 @@ class GvmClientSpec extends Specification {
         gvmClient.restClient = mockRestClient
 
         when:
-        gvmClient.getCandidates()
+        gvmClient.getRemoteCandidates()
 
         then:
         mockRestClient.get(_) >> { throw new HTTPClientException("boom")}

--- a/src/test/groovy/net/gvmtool/client/GvmClientSpec.groovy
+++ b/src/test/groovy/net/gvmtool/client/GvmClientSpec.groovy
@@ -39,16 +39,27 @@ class GvmClientSpec extends Specification {
         thrown(GvmClientException)
     }
 
-    void "should retrieve all versions for existing candidate"() {
+    void "should retrieve all remote versions for existing candidate"() {
         given:
         def candidate = "groovy"
 
         when:
-        List<Version> versions = gvmClient.getVersionsFor(candidate)
+        List<String> versions = gvmClient.getRemoteVersionsFor(candidate)
 
         then:
-        versions.find { it.name == "2.2.1" }
-        versions.find { it.name == "2.1.9" }
+        versions.find { it == "2.2.1" }
+        versions.find { it == "2.1.9" }
+    }
+
+    void "should return an empty list for non existing candidate"() {
+        given:
+        def candidate = "dada3*"
+
+        when:
+        List<String> versions = gvmClient.getRemoteVersionsFor(candidate)
+
+        then:
+        versions.empty
     }
 
     void "should handle communication error on retrieving candidate versions"() {
@@ -58,7 +69,7 @@ class GvmClientSpec extends Specification {
         gvmClient.restClient = mockRestClient
 
         when:
-        gvmClient.getVersionsFor(candidate)
+        gvmClient.getRemoteVersionsFor(candidate)
 
         then:
         mockRestClient.get(_) >> { throw new HTTPClientException("boom")}


### PR DESCRIPTION
- make the remote call clear at the GvmClient
- added gvmHome for better test-ability (the next step will be access to the local storage)
- separation of high level api (e.g. Candidate and Version) from the low level rest api calls - we didn't  implement something at the high level api

thx to @aalmiray , @madmarkus , @sbrannen , @stevendick , @vad1mo and the mad woman with the stones 
